### PR TITLE
Update Telegram sessions for both scripts

### DIFF
--- a/.github/workflows/sync-tzevaadomm-telegram.yml
+++ b/.github/workflows/sync-tzevaadomm-telegram.yml
@@ -1,8 +1,8 @@
-name: Sync IDF Messages
+name: Sync Tzevaadomm Messages
 
 on:
   schedule:
-    - cron: '0 1 * * *' # Runs daily at 1 AM UTC
+    - cron: '0 2 * * *' # Runs daily at 2 AM UTC
   workflow_dispatch:
 
 jobs:
@@ -42,17 +42,13 @@ jobs:
     - name: Install dependencies
       run: pip install --no-cache-dir -r requirements.txt
 
-    - name: Run IDF Telegram scraping script
+    - name: Run Tzevaadomm Telegram scraping script
       env:
         TELEGRAM_API_ID: ${{ secrets.TELEGRAM_API_ID }}
         TELEGRAM_API_HASH: ${{ secrets.TELEGRAM_API_HASH }}
-        R2_ACCESS_KEY: ${{ secrets.R2_ACCESS_KEY }}
-        R2_SECRET_KEY: ${{ secrets.R2_SECRET_KEY }}
-        R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
-        R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        python export_idf_telegram.py
+        python export_tzevaadomm_telegram.py
 
     - name: Commit and push changes
       run: |

--- a/code/telegram/export_idf_telegram.py
+++ b/code/telegram/export_idf_telegram.py
@@ -34,7 +34,7 @@ s3_client = boto3.client(
 )
 
 # Initialize the Telegram client
-client = TelegramClient('session_name', API_ID, API_HASH)
+client = TelegramClient('session_telegram_scraper', API_ID, API_HASH)
 
 # Ensure consistent paths for S3 and URLs
 def normalize_file_key(file_path):

--- a/code/telegram/export_tzevaadomm_telegram.py
+++ b/code/telegram/export_tzevaadomm_telegram.py
@@ -17,7 +17,7 @@ STATE_FILE = "tzevaadomm_id.json"
 START_DATE = datetime(2023, 10, 7, tzinfo=timezone.utc)  # Start scraping from this date (UTC)
 
 # Initialize Telegram client
-client = TelegramClient("new_channel_session", API_ID, API_HASH)
+client = TelegramClient("session_telegram_scraper", API_ID, API_HASH)
 
 # Function to load the last scraped message ID
 def load_last_message_id():


### PR DESCRIPTION
Update Telegram scraping scripts and workflows to use the same session and credentials.

* **export_tzevaadomm_telegram.py**
  - Change session name to `session_telegram_scraper`.

* **sync-idf-telegram.yml**
  - Remove commented-out step for running `export_tzevaadomm_telegram.py`.

* **sync-tzevaadomm-telegram.yml**
  - Add new workflow for `export_tzevaadomm_telegram.py` with shared session and credentials.

* **export_idf_telegram.py**
  - Change session name to `session_telegram_scraper`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/IMS-Network/iron-swords-data/pull/57?shareId=da765069-049e-4895-a6f8-eacca4a2bb2a).